### PR TITLE
feat: 書籍の表紙URLを格納するカラムを追加

### DIFF
--- a/db/migrate/20250408123108_add_cover_image_url_to_books.rb
+++ b/db/migrate/20250408123108_add_cover_image_url_to_books.rb
@@ -1,0 +1,5 @@
+class AddCoverImageUrlToBooks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :books, :cover_image_url, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_25_131136) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_08_123108) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "email"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_25_131136) do
     t.string "isbn"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "cover_image_url", null: false
   end
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,22 +62,26 @@ books_data = [
   {
     title: "「エンジニア×スタートアップ」こそ、最高のキャリアである",
     url: "https://books.rakuten.co.jp/rb/17314436/?l-id=search-c-item-text-05",
-    isbn: "9784295407775"
+    isbn: "9784295407775",
+    cover_image_url: "https://books.rakuten.co.jp/rb/17314436/?rafcid=wsc_b_bs_8a2a6cdb7ded801eeedc109f86ede416"
   },
   {
     title: "マンガでわかるデータベース",
     url: "https://books.rakuten.co.jp/rb/3712479/?l-id=search-c-item-text-01",
-    isbn: "9784274066313"
+    isbn: "9784274066313",
+    cover_image_url: "https://books.rakuten.co.jp/rb/3712479/?rafcid=wsc_b_bs_8a2a6cdb7ded801eeedc109f86ede416"
   },
   {
     title: "イラスト図解式 この一冊で全部わかるWeb技術の基本",
     url: "https://books.rakuten.co.jp/rb/14674807/?l-id=item-c-reco-slider&rtg=103322d9a83bee379262ea7a59a2dc51",
-    isbn: "9784797388817"
+    isbn: "9784797388817",
+    cover_image_url: "https://books.rakuten.co.jp/rb/14674807/?rafcid=wsc_b_bs_8a2a6cdb7ded801eeedc109f86ede416"
   },
   {
     title: "ゼロからわかるRuby超入門はじめてのプログラミング（かんたんIT基礎講座）",
     url: "https://books.rakuten.co.jp/rb/15664673/?l-id=item-c-reco-slider&rtg=103322d9a83bee379262ea7a59a2dc51",
-    isbn: "9784297101237"
+    isbn: "9784297101237",
+    cover_image_url: "https://books.rakuten.co.jp/rb/15664673/?rafcid=wsc_b_bs_8a2a6cdb7ded801eeedc109f86ede416"
   }
 ]
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,6 +89,7 @@ created_books = books_data.map do |book_data|
   Book.find_or_create_by!(isbn: book_data[:isbn]) do |book|
     book.title = book_data[:title]
     book.url = book_data[:url]
+    book.cover_image_url = book_data[:cover_image_url]
   end
 end
 


### PR DESCRIPTION
# issue
close: #38 
関係のあるissue: 

# 実装概要
- マイグレーションファイルを作成し、カラムを追加
- `seeds.rb` を修正

```
bin/rails g migration AddCoverImageUrlToBooks cover_image_url:string
```

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 実装進捗状況
実装状況が分かるようにここに更新していく
実装できたらチェックを入れる

- [ ] 実装内容
- [ ] 実装内容
- [ ] 実装内容

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] `books` テーブルに画像格納用のカラムが追加されていること
- [ ] `null: false` になっていること

## 最終作業者
最後に作業しレビュー依頼を出した方はこちらに名前をお願いします


## 補足・備考
なにかあれば

# 進捗報告コメント用テンプレ
コメントに進捗報告する際は下記のテンプレをご利用ください

## 作業日
作業した日付を書く

## 進捗
どんな作業をしたか、どこまでやったか、どこからやっていないか、などなど

## 次回作業者への共有事項
共有したいことあればここに書く

## 補足・備考
