### PR TITLE
書籍詳細の遷移先のみ追加

### DIFF
--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -6,18 +6,20 @@
   <div class="flex justify-center">
   <ul class="w-full max-w-2xl">
     <% @books.each do |book| %>
-      <li class="mb-4 p-4 border rounded shadow mt-4">
-        <%= image_tag(book.cover_image_url) %>
-        <strong class="block text-lg font-semibold mb-2">タイトル:</strong>
-        <span class="block mb-2"><%= book.title %></span>
-        <strong class="block text-lg font-semibold mb-2">ユーザー名:</strong>
-        <span class="block mb-2"><%= @user.name %></span>
-        <strong class="block text-lg font-semibold mb-2">読了日時:</strong>
-        <span class="block">仮読了日時</span>
-      </li>
+      <%= link_to list_book_path(book), class: "block mb-4 p-4 border rounded shadow mt-4" do %>
+        <div>
+          <%= image_tag(book.cover_image_url, class: "mb-2") %>
+          <strong class="block text-lg font-semibold mb-2">タイトル:</strong>
+          <span class="block mb-2"><%= book.title %></span>
+          <strong class="block text-lg font-semibold mb-2">ユーザー名:</strong>
+          <span class="block mb-2"><%= @user.name %></span>
+          <strong class="block text-lg font-semibold mb-2">読了日時:</strong>
+          <span class="block">仮読了日時</span>
+        </div>
+      <% end %>
     <% end %>
   </ul>
-</div>
+  </div>
   <div class="mt-auto flex justify-center w-full">
     <%= link_to 'Xシェア', "#", class: 'btn btn-primary' %>
   </div>


### PR DESCRIPTION
# issue
close: #[issue番号]
関係のあるissue: #10 

# 実装概要
書籍一覧のカード全体をクリックしたときに、書籍詳細への遷移先を追加

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 実装進捗状況
実装状況が分かるようにここに更新していく
実装できたらチェックを入れる

- [ ] 実装内容
- [ ] 実装内容
- [ ] 実装内容

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] コンソール画面にエラーが出ていないこと
- [ ] 画面遷移図で提案されているUIが概ね再現できている

## 最終作業者
最後に作業しレビュー依頼を出した方はこちらに名前をお願いします

## 補足・備考
なにかあれば

# 進捗報告コメント用テンプレ
コメントに進捗報告する際は下記のテンプレをご利用ください

## 作業日
2025/4/20

## 進捗
どんな作業をしたか、どこまでやったか、どこからやっていないか、などなど

## 次回作業者への共有事項
書籍詳細の中身の実装をお願いいたします

## 補足・備考
