### PR TITLE
ユーザー一覧機能を作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,46 @@
 class UsersController < ApplicationController
+  before_action :set_user, only: [:show, :edit, :update]
+  rescue_from ActiveRecord::RecordNotFound, with: :user_not_found
+
+  def index
+    @users = User.publicly_visible.order(created_at: :desc).includes(:lists) 
+  end
+  
   def show
-    @user = User.find(params[:id])
+    unless @user.is_public
+      
+      #TODO: ログイン機能実装後、current_userに一致せず、かつ非公開の場合は一覧に遷移するロジックを追加
+      # if current_user && current_user.id == @user.id
+      # # 自分自身のページなのでアクセス許可
+      # else
+      # 他のユーザーの非公開ページなのでリダイレクト
+      # TODO: フラッシュメッセージを実装予定
+      # 　flash[:alert] = "このユーザーページは非公開に設定されています"
+      # 　redirect_to users_path and return
+      # end
+
+      # ログイン機能実装までの暫定対応
+      redirect_to users_path and return
+    end
   end
 
   def edit
-    @user = User.find(params[:id])
+    # TODO：ログイン機能実装後下記の追加予定
+    # unless current_user && current_user.id == @user.id
+    #   flash[:alert] = "他のユーザー情報は編集できません"
+    #   redirect_to users_path and return
+    # end# unless current_user && current_user.id == @user.id
+    #   flash[:alert] = "他のユーザー情報は編集できません"
+    #   redirect_to users_path and return
+    # end
   end
 
   def update
-    @user = User.find(params[:id])
+    # TODO：ログイン機能実装後下記の追加予定
+    # unless current_user && current_user.id == @user.id
+    #   flash[:alert] = "他のユーザー情報は更新できません"
+    #   redirect_to users_path and return
+    # end
 
     if @user.update(user_params)
       # ユーザーが非公開になるとリストも全て非公開にする
@@ -23,6 +55,19 @@ class UsersController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_not_found
+    # TODO: フラッシュメッセージを実装予定
+    # flash[:alert] = "指定されたユーザーは存在しません"
+    redirect_to users_path
+  end
+
 
   def user_params
     params.require(:user).permit(:name, :engineer_start_date, :profile_content, :is_public)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   has_one :authentication, dependent: :destroy
 
   validates :name, presence: true
+  scope :publicly_visible, -> { where(is_public: true) }
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,46 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="font-bold text-4xl text-center mb-6">ユーザー一覧</h1>
+
+  <div class="flex justify-center mb-8 space-x-4">
+    <%= link_to 'TOPへ戻る', root_path, class: 'btn btn-primary' %>
+    <%#<%= link_to 'ユーザー登録', new_user_path, class: 'btn btn-primary' %>
+  </div>
+
+  <div class="flex justify-center mb-12">
+    <ul class="grid gap-6 w-full max-w-2xl sm:grid-cols-2 lg:grid-cols-3">
+      <% @users.each do |user| %>
+        <li class="card bg-base-100 shadow-md border hover:shadow-lg transition-shadow duration-300">
+          <div class="card-body p-6">
+
+            <!-- ユーザーごとの基本情報 -->
+            <div class="flex items-center gap-4 mb-2 pb-2">
+              <div class="w-full">
+                <p class="text-lg font-bold mb-1"><%= user.name %></p>
+                <% if user.engineer_start_date.present? %>
+                  <p class="text-sm text-gray-500">
+                    エンジニア歴
+                    <!-- エンジニア開始日と今日の日付差分をdistance_of_time_in_wordsで処理。日本語化 -->
+                    <%= distance_of_time_in_words(user.engineer_start_date, Date.current, locale: :ja) %>
+                  </p>
+                <% end %>
+              </div>
+            </div>
+
+            <!-- リスト数 -->
+            <div class="mb-4">
+              <span class="badge badge-outline badge-md">
+                公開リスト
+                <span class="ml-1 font-semibold"><%= user.lists.where(is_public: true).count %></span>
+                件
+              </span>
+            </div>
+
+            <div class="card-actions justify-end mt-auto pt-2">
+              <%= link_to '詳細を見る', user_path(user), class: 'btn btn-primary btn-sm' %>
+            </div>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,6 +33,7 @@
   </div>
 </div>
 
-<div class="mt-8 flex justify-center">
+<div class="mt-8 mb-2 flex justify-center">
+  <%= link_to 'ユーザー一覧へ戻る', users_path, class: 'btn btn-primary mr-2'  %>
   <%= link_to 'TOPへ戻る', root_path, class: 'btn btn-primary' %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.available_locales = [:en, :ja]
     config.autoload_paths += %W(#{config.root}/app/services)
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,28 +1,6 @@
 ja:
   datetime:
     distance_in_words:
-      half_a_minute: "30秒"
-
-      less_than_x_seconds:
-        one: "1秒未満"
-        other: "%{count}秒未満"
-
-      x_seconds:
-        one: "1秒"
-        other: "%{count}秒"
-
-      less_than_x_minutes:
-        one: "1分未満"
-        other: "%{count}分未満"
-
-      x_minutes:
-        one: "1分"
-        other: "%{count}分"
-
-      about_x_hours:
-        one: "約1時間"
-        other: "約%{count}時間"
-
       x_days:
         one: "1日"
         other: "%{count}日"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,52 @@
+ja:
+  datetime:
+    distance_in_words:
+      half_a_minute: "30秒"
+
+      less_than_x_seconds:
+        one: "1秒未満"
+        other: "%{count}秒未満"
+
+      x_seconds:
+        one: "1秒"
+        other: "%{count}秒"
+
+      less_than_x_minutes:
+        one: "1分未満"
+        other: "%{count}分未満"
+
+      x_minutes:
+        one: "1分"
+        other: "%{count}分"
+
+      about_x_hours:
+        one: "約1時間"
+        other: "約%{count}時間"
+
+      x_days:
+        one: "1日"
+        other: "%{count}日"
+
+      about_x_months:
+        one: "約1か月"
+        other: "約%{count}か月"
+
+      x_months:
+        one: "1か月"
+        other: "%{count}か月"
+
+      about_x_years:
+        one: "約1年"
+        other: "約%{count}年"
+
+      over_x_years:
+        one: "1年以上"
+        other: "%{count}年以上"
+
+      almost_x_years:
+        one: "1年弱"
+        other: "%{count}年弱"
+
+      a_day:
+        one: "1日"
+        other: "1日"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get "/login", to: "sessions#new", as: :login
   delete "/logout", to: "sessions#destroy", as: :logout
 
-  resources :users, only: %i[show edit update]
+  resources :users, only: %i[index show edit update]
   resources :lists do
     resources :books, except: %i[index]
   end


### PR DESCRIPTION
# issue
close: #17 
関係のあるissue: 

# 実装概要
- users_pathにユーザー一覧ページを実装した
 - 非公開ユーザーのページにURLダイレクトアクセスするとユーザー一覧に遷移するようにした 
 - is_publicがtrueのuserのみの情報を扱うため、あらかじめuserモデルにて`scope :publicly_visible, -> { where(is_public: true) }`とした
 - 所有リスト数のカウント時にN+1問題が発生するので`@users = User.publicly_visible.order(created_at: :desc).includes(:lists) `とした
 - ユーザー一覧に示すエンジニア歴は`<%= distance_of_time_in_words(user.engineer_start_date, Date.current, locale: :ja) %>`で差分計算をさせている。この際、日本語化を行なっているので`application.rb`, `config/initializers/ja.yml`でその旨の対応を行なった
- ユーザー詳細ページからユーザー一覧ページに移動するボタンを設置した 

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 実装進捗状況
実装状況が分かるようにここに更新していく
実装できたらチェックを入れる

- [x] ユーザー一覧ページを作成
- [x] 非公開ユーザーのページにURLダイレクトアクセスするとユーザー一覧に遷移 
- [ ] 実装内容

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 
- [ ] 
- [ ] 

## 最終作業者
最後に作業しレビュー依頼を出した方はこちらに名前をお願いします


## 補足・備考
- 日本語化ファイルを変更していますので、docker再起動が必要です

# 進捗報告コメント用テンプレ
コメントに進捗報告する際は下記のテンプレをご利用ください

## 作業日
作業した日付を書く

## 進捗
どんな作業をしたか、どこまでやったか、どこからやっていないか、などなど

## 次回作業者への共有事項
- ログイン機能実装前について暫定的な処理になっています。公開設定がfalseであってもcurrent_userであれば遷移できる処理の実装案をコメントアウトで記載しています

## 補足・備考
