### PR TITLE
userコントローラにcurrent_userを反映

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   
   def require_login
     unless logged_in?
-      flash[:alert] = "ログインしてください"
+      flash[:warning] = "ログインしてください"
       redirect_to root_path
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,11 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   include SessionsHelper
   add_flash_types :success, :warning
+  
+  def require_login
+    unless logged_in?
+      flash[:alert] = "ログインしてください"
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
     unless @user.is_public
       # ログインユーザーが自分自身の場合は表示、それ以外はリダイレクト
       unless current_user && current_user.id == @user.id
-        flash[:alert] = "このユーザーページは非公開に設定されています"
+        flash[:warning] = "このユーザーページは非公開に設定されています"
         redirect_to users_path and return
       end
     end
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
           list.save!
         end
       end
-      redirect_to user_path(params[:id]), notice: "ユーザー情報を更新しました"
+      redirect_to user_path(params[:id]), success: "ユーザー情報を更新しました"
     else
       render :edit, status: :unprocessable_entity
     end
@@ -46,13 +46,13 @@ class UsersController < ApplicationController
 
   def authorize_user
     unless current_user && current_user.id == @user.id
-      flash[:alert] = "他のユーザー情報は編集できません"
+      flash[:warning] = "他のユーザー情報は編集できません"
       redirect_to users_path and return
     end
   end
 
   def user_not_found
-    flash[:alert] = "指定されたユーザーは存在しません"
+    flash[:warning] = "指定されたユーザーは存在しません"
     redirect_to users_path
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update]
+  before_action :authorize_user, only: [:edit, :update]
+  before_action :require_login
   rescue_from ActiveRecord::RecordNotFound, with: :user_not_found
 
   def index
@@ -8,40 +10,20 @@ class UsersController < ApplicationController
   
   def show
     unless @user.is_public
-      
-      #TODO: ログイン機能実装後、current_userに一致せず、かつ非公開の場合は一覧に遷移するロジックを追加
-      # if current_user && current_user.id == @user.id
-      # # 自分自身のページなのでアクセス許可
-      # else
-      # 他のユーザーの非公開ページなのでリダイレクト
-      # TODO: フラッシュメッセージを実装予定
-      # 　flash[:alert] = "このユーザーページは非公開に設定されています"
-      # 　redirect_to users_path and return
-      # end
-
-      # ログイン機能実装までの暫定対応
-      redirect_to users_path and return
+      # ログインユーザーが自分自身の場合は表示、それ以外はリダイレクト
+      unless current_user && current_user.id == @user.id
+        flash[:alert] = "このユーザーページは非公開に設定されています"
+        redirect_to users_path and return
+      end
     end
   end
 
   def edit
-    # TODO：ログイン機能実装後下記の追加予定
-    # unless current_user && current_user.id == @user.id
-    #   flash[:alert] = "他のユーザー情報は編集できません"
-    #   redirect_to users_path and return
-    # end# unless current_user && current_user.id == @user.id
-    #   flash[:alert] = "他のユーザー情報は編集できません"
-    #   redirect_to users_path and return
-    # end
+    # authorize_userメソッドで処理
   end
 
   def update
-    # TODO：ログイン機能実装後下記の追加予定
-    # unless current_user && current_user.id == @user.id
-    #   flash[:alert] = "他のユーザー情報は更新できません"
-    #   redirect_to users_path and return
-    # end
-
+    # authorize_userメソッドで処理
     if @user.update(user_params)
       # ユーザーが非公開になるとリストも全て非公開にする
       unless @user.is_public
@@ -50,7 +32,7 @@ class UsersController < ApplicationController
           list.save!
         end
       end
-      redirect_to user_path(params[:id])
+      redirect_to user_path(params[:id]), notice: "ユーザー情報を更新しました"
     else
       render :edit, status: :unprocessable_entity
     end
@@ -62,9 +44,15 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def authorize_user
+    unless current_user && current_user.id == @user.id
+      flash[:alert] = "他のユーザー情報は編集できません"
+      redirect_to users_path and return
+    end
+  end
+
   def user_not_found
-    # TODO: フラッシュメッセージを実装予定
-    # flash[:alert] = "指定されたユーザーは存在しません"
+    flash[:alert] = "指定されたユーザーは存在しません"
     redirect_to users_path
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,8 +1,10 @@
 <h1 class="font-bold text-4xl text-center mb-4">プロフィール</h1>
 
-<div class="flex justify-center">
-  <%= link_to '編集', edit_user_path(@user), class: 'btn btn-primary mr-2' %>
-</div>
+<% if current_user && current_user.id == @user.id %>
+  <div class="flex justify-center">
+    <%= link_to '編集', edit_user_path(@user), class: 'btn btn-primary mr-2' %>
+  </div>
+<% end %>
 
 <div class="flex justify-center mt-6">
   <div class="w-full max-w-md p-6 border rounded shadow">


### PR DESCRIPTION
# issue
close: #52 
関係のあるissue: 

# 実装概要
ログイン機能が実装されたので、ログインユーザーか/そうでないかで、挙動の振り分けを行う
`current_user`はもともと作成されていた`app/helpers/sessions_helper.rb`をそのまま使用
`users_controller.rb`にbefore_actionにログインユーザーと一致しているかの判定を行う


## 追加実装
`application_cntrller.rb`で`require_login`を実装

## 実装進捗状況
実装状況が分かるようにここに更新していく
実装できたらチェックを入れる

- [x] current_userの反映
- [ ] 実装内容
- [ ] 実装内容

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 
- [ ] 
- [ ] 

## 最終作業者
最後に作業しレビュー依頼を出した方はこちらに名前をお願いします


## 補足・備考
なにかあれば

# 進捗報告コメント用テンプレ
コメントに進捗報告する際は下記のテンプレをご利用ください

## 作業日
作業した日付を書く

## 進捗


## 次回作業者への共有事項
before_actionを効かせる場所がusers_cntrollerでよかったのか、ログインなしでアクセスするユーザーへの対応として不十分な気がするので、要件見据えて修正する

## 補足・備考
