### PR TITLE
feat:読了日の年移動追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@
 /config/credentials/development.key
 
 /config/credentials/production.key
+
+/docs

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,15 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
-import "controllers"
+import '@hotwired/turbo-rails';
+import 'controllers';
+
+window.changeYear = function(isbn, direction, event) {
+  //年移動はcallyによる月移動イベントの伝搬を防ぐ
+  if (event) event.stopPropagation();
+
+  const yearDisplay = document.getElementById(`year-display-${isbn}`);
+  if (!yearDisplay) return;
+
+  const currentYear = parseInt(yearDisplay.textContent);
+  const newYear = currentYear + direction;
+  yearDisplay.textContent = newYear + '年';
+};

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,7 +2,7 @@
 import '@hotwired/turbo-rails';
 import 'controllers';
 
-window.changeYear = function(isbn, direction, event) {
+window.changeYear = function (isbn, direction, event) {
   //年移動はcallyによる月移動イベントの伝搬を防ぐ
   if (event) event.stopPropagation();
 
@@ -12,4 +12,24 @@ window.changeYear = function(isbn, direction, event) {
   const currentYear = parseInt(yearDisplay.textContent);
   const newYear = currentYear + direction;
   yearDisplay.textContent = newYear + '年';
+
+  const calendarDate = document.querySelector(
+    `#year-calendar-popover${isbn} calendar-date`
+  );
+  if (calendarDate) {
+    let currentMonth = calendarDate.value
+      ? new Date(calendarDate.value).getMonth()
+      : new Date().getMonth();
+
+    const newDate = new Date(newYear, currentMonth, 1);
+    // callyのAPIがあればsetDate、なければvalue属性を直接変更
+    if (typeof calendarDate.setDate === 'function') {
+      calendarDate.setDate(newDate);
+    } else {
+      const y = newDate.getFullYear();
+      const m = String(newDate.getMonth() + 1).padStart(2, '0');
+      calendarDate.value = `${y}-${m}-01`;
+      calendarDate.setAttribute('value', `${y}-${m}-01`);
+    }
+  }
 };

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -38,8 +38,15 @@
             <%= form.hidden_field :read_completed_at, id: "read_completed_at-#{book[:isbn]}" %>
             <div popover id="cally-popover<%= book[:isbn] %>" class="dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally<%= book[:isbn] %>">
               <calendar-date class="cally" onChange="document.getElementById('cally-<%= book[:isbn] %>').innerText = this.value;document.getElementById('read_completed_at-<%= book[:isbn] %>').value = this.value;document.getElementById('submit-<%= book[:isbn] %>').disabled = false;" max="<%= Date.today %>" locale="ja-JP">
-                <svg aria-label="Previous" class="fill-current size-4" slot="previous" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.75 19.5 8.25 12l7.5-7.5"></path></svg>
-                <svg aria-label="Next" class="fill-current size-4" slot="next" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"></path></svg>
+                <span slot="previous" class="flex items-center gap-1">
+                  <button type="button" class="btn btn-xs" onclick="changeYear('<%= book[:isbn] %>', -1, event)"><<</button>
+                  <svg aria-label="Previous" class="fill-current size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.75 19.5 8.25 12l7.5-7.5"></path></svg>
+                </span>
+                <span slot="next" class="flex items-center gap-1">
+                  <svg aria-label="Next" class="fill-current size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"></path></svg>
+                  <button type="button" class="btn btn-xs" onclick="changeYear('<%= book[:isbn] %>', 1, event)">>></button>
+                </span>
+                <span id="year-display-<%= book[:isbn] %>" class="font-bold text-lg"><%= Date.current.year %>年</span>
                 <calendar-month></calendar-month>
               </calendar-date>
             </div>

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -32,11 +32,11 @@
               <%= form.label :read_completed_at, "読了日", class: "block text-lg font-semibold mb-1" %>
               <span class="text-red-600 align-top">*</span>
             </div>
-            <button type="button" popovertarget="cally-popover<%= book[:isbn] %>" class="input input-border w-full" style="anchor-name:--cally<%= book[:isbn] %>" id="cally-<%= book[:isbn] %>">
+            <button type="button" popovertarget="year-calendar-popover<%= book[:isbn] %>" class="input input-border w-full" style="anchor-name:--cally<%= book[:isbn] %>" id="cally-<%= book[:isbn] %>">
               読了日
             </button>
             <%= form.hidden_field :read_completed_at, id: "read_completed_at-#{book[:isbn]}" %>
-            <div popover id="cally-popover<%= book[:isbn] %>" class="dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally<%= book[:isbn] %>">
+            <div popover id="year-calendar-popover<%= book[:isbn] %>" class="dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally<%= book[:isbn] %>">
               <calendar-date class="cally" onChange="document.getElementById('cally-<%= book[:isbn] %>').innerText = this.value;document.getElementById('read_completed_at-<%= book[:isbn] %>').value = this.value;document.getElementById('submit-<%= book[:isbn] %>').disabled = false;" max="<%= Date.today %>" locale="ja-JP">
                 <span slot="previous" class="flex items-center gap-1">
                   <button type="button" class="btn btn-xs" onclick="changeYear('<%= book[:isbn] %>', -1, event)"><<</button>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -20,11 +20,11 @@
       <%= form_with model: @list_book, url: list_book_path(list_id: @list.id, id: @book.id), data: { turbo: true }, class: "text-start w-full flex flex-col items-start gap-4" do |f| %>
         <div>
           <h3 class="text-lg font-semibold">読了日</h3>
-          <button type="button" popovertarget="cally-popover<%= @book.isbn %>" class="input input-border w-full" style="anchor-name:--cally<%= @book.isbn %>" id="cally-<%= @book.isbn %>">
+          <button type="button" popovertarget="year-calendar-popover<%= @book.isbn %>" class="input input-border w-full" style="anchor-name:--cally<%= @book.isbn %>" id="cally-<%= @book.isbn %>">
             読了日
           </button>
           <%= f.hidden_field :read_completed_at, id: "read_completed_at-#{@book.isbn}" %>
-          <div popover id="cally-popover<%= @book.isbn %>" class="dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally<%= @book.isbn %>">
+          <div popover id="year-calendar-popover<%= @book.isbn %>" class="dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally<%= @book.isbn %>">
             <calendar-date class="cally"
               onChange="document.getElementById('cally-<%= @book.isbn %>').innerText = this.value;
                         document.getElementById('read_completed_at-<%= @book.isbn %>').value = this.value;

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -19,17 +19,32 @@
     <section class="w-full">
       <%= form_with model: @list_book, url: list_book_path(list_id: @list.id, id: @book.id), data: { turbo: true }, class: "text-start w-full flex flex-col items-start gap-4" do |f| %>
         <div>
-          <h3 class="text-lg font-semibold">読了日<span class="text-red-600 align-top">*</span></h3>
-          <button type="button" popovertarget="cally-popover1" class="input input-border" style="anchor-name:--cally1" id="cally1">
-            <%= @list_book.read_completed_at %>
+          <h3 class="text-lg font-semibold">読了日</h3>
+          <button type="button" popovertarget="cally-popover<%= @book.isbn %>" class="input input-border w-full" style="anchor-name:--cally<%= @book.isbn %>" id="cally-<%= @book.isbn %>">
+            読了日
           </button>
-          <%= f.hidden_field :read_completed_at, id: "read_completed_at" %>
-          <div popover id="cally-popover1" class="dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally1">
-            <calendar-date class="cally" onChange="document.getElementById('cally1').innerText = this.value;document.getElementById('read_completed_at').value = this.value;" max="<%= Date.today %>" locale="ja-JP">
-              <svg aria-label="Previous" class="fill-current size-4" slot="previous" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.75 19.5 8.25 12l7.5-7.5"></path></svg>
-              <svg aria-label="Next" class="fill-current size-4" slot="next" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"></path></svg>
+          <%= f.hidden_field :read_completed_at, id: "read_completed_at-#{@book.isbn}" %>
+          <div popover id="cally-popover<%= @book.isbn %>" class="dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally<%= @book.isbn %>">
+            <calendar-date class="cally"
+              onChange="document.getElementById('cally-<%= @book.isbn %>').innerText = this.value;
+                        document.getElementById('read_completed_at-<%= @book.isbn %>').value = this.value;
+                        document.getElementById('submit-<%= @book.isbn %>').disabled = false;"
+              max="<%= Date.today %>" locale="ja-JP">
+              <span slot="previous" class="flex items-center gap-1">
+                <button type="button" class="btn btn-xs" onclick="changeYear('<%= @book.isbn %>', -1, event)"><<</button>
+                <svg aria-label="Previous" class="fill-current size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                  <path d="M15.75 19.5 8.25 12l7.5-7.5"></path>
+                </svg>
+              </span>
+              <span slot="next" class="flex items-center gap-1">
+                <svg aria-label="Next" class="fill-current size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                  <path d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+                </svg>
+                <button type="button" class="btn btn-xs" onclick="changeYear('<%= @book.isbn %>', 1, event)">>></button>
+              </span>
+              <span id="year-display-<%= @book[:isbn] %>" class="font-bold text-lg"><%= Date.current.year %>年</span>
               <calendar-month></calendar-month>
-            </calendar-date>
+            </calendar-date>    
           </div>
         </div>
         <div class="w-full">


### PR DESCRIPTION
# issue
close: #124 125 126
関係のあるissue: 

# 実装概要
実装した内容をここに書く
現在使用しているcallyのカスタムで年移動ができるようにする

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く
カスタムにしたので軽くフロントの実装
app/views/books/_book.html.erb
app/views/books/edit.html.erb
- [x] 年移動ボタンの表示
- [x] ボタンで翌年、前年を選択
- [ ] 選択された年にカレンダー内容も遷移する
- [x] 年移動の際はcallyの月移動を作動させない

## 実装進捗状況
実装状況が分かるようにここに更新していく
実装できたらチェックを入れる

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [x] 年・月の移動ができるカレンダーUIが選定できた
- [x] 日本語表記やカスタマイズ性も確認できた
- [ ] 技術検証の結果がドキュメント化されている

## 最終作業者
最後に作業しレビュー依頼を出した方はこちらに名前をお願いします

## 補足・備考
なにかあれば

# 進捗報告コメント用テンプレ
コメントに進捗報告する際は下記のテンプレをご利用ください

## 作業日
作業した日付を書く

## 進捗
どんな作業をしたか、どこまでやったか、どこからやっていないか、などなど

## 次回作業者への共有事項
共有したいことあればここに書く

## 補足・備考
